### PR TITLE
Allow admin to create and update presentation dates

### DIFF
--- a/app/controllers/admin/innings_controller.rb
+++ b/app/controllers/admin/innings_controller.rb
@@ -1,4 +1,8 @@
 class Admin::InningsController < Admin::BaseController
+  def show
+    @inning = Inning.find(params[:id])
+  end
+
   def new
     @inning = Inning.new
   end

--- a/app/controllers/admin/presentations_controller.rb
+++ b/app/controllers/admin/presentations_controller.rb
@@ -1,0 +1,39 @@
+class Admin::PresentationsController < Admin::BaseController
+  def new
+    @inning       = Inning.find(params[:inning_id])
+    @presentation = @inning.presentations.new
+  end
+
+  def create
+    @inning = Inning.find(params[:inning_id])
+    @presentation = @inning.presentations.new(presentation_params)
+    if @presentation.save
+      flash[:success] = "Successfully created presentation date."
+      redirect_to admin_inning_path(@inning)
+    else
+      flash[:error] = "Something went wrong."
+      render :new
+    end
+  end
+
+  def edit
+    @presentation = Presentation.find(params[:id])
+    @inning = @presentation.inning
+  end
+
+  def update
+    @presentation = Presentation.find(params[:id])
+    if @presentation.update(presentation_params)
+      flash[:success] = "Successfully updated presentation date"
+      redirect_to admin_inning_path(@presentation.inning)
+    else
+      flash[:error] = "Something went wrong."
+      render :edit
+    end
+  end
+
+  private
+  def presentation_params
+    params.require(:presentation).permit(:date, :due_date)
+  end
+end

--- a/app/models/inning.rb
+++ b/app/models/inning.rb
@@ -1,2 +1,3 @@
 class Inning < ApplicationRecord
+  has_many :presentations
 end

--- a/app/models/presentation.rb
+++ b/app/models/presentation.rb
@@ -1,0 +1,7 @@
+class Presentation < ApplicationRecord
+  belongs_to :inning
+
+  def formatted_date
+    date.strftime("%B %-d, %Y")
+  end
+end

--- a/app/views/admin/innings/show.html.erb
+++ b/app/views/admin/innings/show.html.erb
@@ -1,0 +1,10 @@
+<h2><%= @inning.name %></h2>
+
+<%= link_to "Add a Presentation Date", new_admin_inning_presentation_path(@inning) %>
+
+<ul>
+  <% @inning.presentations.each_with_index do |presentation, index| %>
+    <li>Presentation Date <%= index + 1 %>: <%= presentation.formatted_date %> <%= link_to "Edit", edit_admin_inning_presentation_path(@inning, presentation) %></li>
+  <% end %>
+</ul>
+

--- a/app/views/admin/presentations/_form.html.erb
+++ b/app/views/admin/presentations/_form.html.erb
@@ -1,0 +1,7 @@
+<%= form_for([:admin, @inning, @presentation]) do |f| %>
+  <%= f.label :date %>
+  <%= f.date_field :date %>
+  <%= f.label :due_date %>
+  <%= f.date_field :due_date, order: ['day', 'month', 'year'] %>
+  <%= f.submit "Add Presentation Date" %>
+<% end %>

--- a/app/views/admin/presentations/edit.html.erb
+++ b/app/views/admin/presentations/edit.html.erb
@@ -1,0 +1,3 @@
+<h2>Edit Presentation Date: <%= @presentation.formatted_date %></h2>
+
+<%= render "form" %>

--- a/app/views/admin/presentations/new.html.erb
+++ b/app/views/admin/presentations/new.html.erb
@@ -1,0 +1,3 @@
+<h2>Create a New Presentation Date</h2>
+
+<%= render "form" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
 
   namespace 'admin' do
     get 'dashboard', to: 'dashboards#show'
-    resources :innings, only: [:new, :create]
+    resources :innings, only: [:show, :new, :create] do
+      resources :presentations, only: [:new, :create, :edit, :update]
+    end
   end
 end

--- a/db/migrate/20181006031620_create_presentations.rb
+++ b/db/migrate/20181006031620_create_presentations.rb
@@ -1,0 +1,9 @@
+class CreatePresentations < ActiveRecord::Migration[5.2]
+  def change
+    create_table :presentations do |t|
+      t.date :date
+      t.date :due_date
+      t.references :inning, foreign_key: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_05_175912) do
+ActiveRecord::Schema.define(version: 2018_10_06_031620) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,8 +19,16 @@ ActiveRecord::Schema.define(version: 2018_10_05_175912) do
     t.string "name"
   end
 
+  create_table "presentations", force: :cascade do |t|
+    t.date "date"
+    t.date "due_date"
+    t.bigint "inning_id"
+    t.index ["inning_id"], name: "index_presentations_on_inning_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.integer "role", default: 0
   end
 
+  add_foreign_key "presentations", "innings"
 end

--- a/spec/features/admin/can_add_sessions_spec.rb
+++ b/spec/features/admin/can_add_sessions_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe "As an admin" do
+  describe "when I visit the show page for an inning" do
+    it "I can add a session" do
+      inning = Inning.create(name: "1806")
+      visit admin_inning_path(inning)
+
+      click_on("Add a Presentation Date")
+
+      fill_in("presentation[due_date]", with: "10/1/2019")
+      fill_in("presentation[date]", with: "12/1/2019")
+
+      click_on "Add Presentation Date"
+
+      expect(page).to have_content("Successfully created presentation date")
+      expect(page).to have_content("1806")
+      expect(page).to have_content("Presentation Date 1: January 12, 2019")
+    end
+  end
+end

--- a/spec/features/admin/can_create_new_inning_spec.rb
+++ b/spec/features/admin/can_create_new_inning_spec.rb
@@ -5,23 +5,10 @@ describe "As an admin" do
     it "I can create a new inning" do
       visit admin_dashboard_path
 
-      # And I click on create new inning
       click_on("Create New Inning")
-        # and I fill in a form with
-        # fill in the name of inning
       fill_in("inning[name]", with: "1810")
-        # cohorts presenting that inning
-        # cohorts voting that inning
-        # dates of lightning talks
-        # fill_in("Week 2 Date", with: "October 12")
-        # fill_in("Week 3 Date", with: "October 19")
-        # fill_in("Week 4 Date", with: "October 26")
-        # dates that talks are due
-        #  fill_in("Topics Due", with: "October 8")
-        # and I click submit
       click_on("Create Inning")
-      save_and_open_page
-        # then I see a new inning has been created
+
       expect(page).to have_content("Inning was successfully created")
     end
   end

--- a/spec/features/admin/can_edit_presentation_spec.rb
+++ b/spec/features/admin/can_edit_presentation_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe "As an admin" do
+  describe "when I visit the show page for an inning" do
+    it "I can add a session" do
+      inning = Inning.create(name: "1806")
+      inning.presentations.create(date: "12/1/2019", due_date: "10/1/2019")
+
+      visit admin_inning_path(inning)
+
+      click_on("Edit")
+
+      fill_in("presentation[due_date]", with: "9/1/2019")
+      fill_in("presentation[date]", with: "13/1/2019")
+
+      click_on "Add Presentation Date"
+
+      expect(page).to have_content("Successfully updated presentation date")
+      expect(page).to have_content("1806")
+      expect(page).to have_content("Presentation Date 1: January 13, 2019")
+    end
+  end
+end


### PR DESCRIPTION
* Closes #11 
* Admin can create a presentation date to go with an inning.
* Admin can update a presentation date.